### PR TITLE
Fixed prototype pollution in homefront

### DIFF
--- a/dist/lib/expand.js
+++ b/dist/lib/expand.js
@@ -8,9 +8,9 @@
  * @return {{}}
  */
 module.exports = function expand(source) {
-  var destination = {};
+  let destination = {};
 
-  Object.getOwnPropertyNames(source).forEach(function (flatKey) {
+  Object.getOwnPropertyNames(source).forEach(flatKey => {
 
     // If the key doesn't contain a dot (isn't nested), just set the value.
     if (flatKey.indexOf('.') === -1) {
@@ -19,11 +19,14 @@ module.exports = function expand(source) {
       return;
     }
 
-    var tmp  = destination;         // Pointer for the nested object.
-    var keys = flatKey.split('.');  // Keys (path) for the nested object.
-    var key  = keys.pop();          // The last (deepest) key.
+    let tmp  = destination;         // Pointer for the nested object.
+    let keys = flatKey.split('.');  // Keys (path) for the nested object.
+    let key  = keys.pop();          // The last (deepest) key.
 
-    keys.forEach(function (value) {
+    keys.forEach(value => {
+      if(value.includes('__proto__') || value.includes('constructor') || value.includes('prototype')){
+        return destination;
+      }
       if (typeof tmp[value] === 'undefined') {
         tmp[value] = {};
       }

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -24,6 +24,9 @@ module.exports = function expand(source) {
     let key  = keys.pop();          // The last (deepest) key.
 
     keys.forEach(value => {
+      if(value.includes('__proto__') || value.includes('constructor') || value.includes('prototype')){
+        return destination;
+      }
       if (typeof tmp[value] === 'undefined') {
         tmp[value] = {};
       }


### PR DESCRIPTION
### 📊 Metadata *

Prototype Pollution bug

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-homefront/

### ⚙️ Description *

`homefront` is vulnerable to Prototype Pollution.. This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.

### 💻 Technical Description *

The bug is fixed by validating the input `value` to check for prototypes. It is implemented by a simple validation to check for prototype keywords `(__proto__, constructor and prototype)`, where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability. 

### 🐛 Proof of Concept (PoC) *

Clone the project, install the required dependencies and on running the below snippet of code, it triggers prototype pollution and logs `Yes! Its Polluted`.
```javascript
// poc.js
var homefront = require("homefront")
console.log("Before : " + {}.polluted);
homefront.expand({"__proto__.polluted": "Yes! Its Polluted"})
console.log("After : " + {}.polluted);
```




### 🔥 Proof of Fix (PoF) *

After the fix is applied, it returns `undefined` since the polluted referred in the PoC is no more accessible(which is intended). Hence fixing the issue.



### 👍 User Acceptance Testing (UAT)

Just prevented some keywords as `value` and no breaking changes are introduced. :)
