### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/lib/expand.js
+++ b/lib/expand.js
@@ -15,14 +15,14 @@ module.exports = function expand(source) {
     // If the key doesn't contain a dot (isn't nested), just set the value.
     if (flatKey.indexOf('.') === -1) {
       destination[flatKey] = source[flatKey];
-      
+
       return;
     }
-    
+
     let tmp  = destination;         // Pointer for the nested object.
     let keys = flatKey.split('.');  // Keys (path) for the nested object.
     let key  = keys.pop();          // The last (deepest) key.
-    
+
     keys.forEach(value => {
       if (typeof tmp[value] === 'undefined') {
         tmp[value] = {};

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -15,20 +15,21 @@ module.exports = function expand(source) {
     // If the key doesn't contain a dot (isn't nested), just set the value.
     if (flatKey.indexOf('.') === -1) {
       destination[flatKey] = source[flatKey];
-
+      
       return;
     }
-
+    
     let tmp  = destination;         // Pointer for the nested object.
     let keys = flatKey.split('.');  // Keys (path) for the nested object.
     let key  = keys.pop();          // The last (deepest) key.
-
+    
     keys.forEach(value => {
       if (typeof tmp[value] === 'undefined') {
         tmp[value] = {};
       }
 
-      tmp = tmp[value];
+      if (!isPrototypePolluted(value))
+        tmp = tmp[value];
     });
 
     tmp[key] = source[flatKey];
@@ -36,3 +37,12 @@ module.exports = function expand(source) {
 
   return destination;
 };
+
+/**
+ * Blacklist certain keys to prevent Prototype Pollution
+ * @param {string} key
+ * @return {boolean}
+ */
+function isPrototypePolluted(key) {
+  return ['__proto__', 'constructor', 'prototype'].includes(key);
+}


### PR DESCRIPTION
### :bar_chart: Metadata *

`homefront` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-homefront

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
var homefront = require("homefront")
console.log("Before : " + {}.polluted);
homefront.expand({"__proto__.polluted": "Yes! Its Polluted"})
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i homefront # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before: undefined
After: true
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/104122996-75098c00-536e-11eb-8338-43c13e157470.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
